### PR TITLE
Diagnostics: default to main for curl|bash, add branch fallback + docs

### DIFF
--- a/MacOS/Components/Diagnostics/README.md
+++ b/MacOS/Components/Diagnostics/README.md
@@ -7,7 +7,7 @@ Comprehensive diagnostic system for DTU Python development environment setup.
 Run the diagnostic report with a single command:
 
 ```bash
-curl -s https://raw.githubusercontent.com/philipnickel/pythonsupport-scripts/macos-components/MacOS/Components/Diagnostics/generate_report.sh | bash
+curl -fsSL https://raw.githubusercontent.com/philipnickel/pythonsupport-scripts/main/MacOS/Components/Diagnostics/generate_report.sh | bash
 ```
 
 This will:
@@ -16,6 +16,27 @@ This will:
 - Generate an interactive HTML report with detailed logs
 - Open the report in your default browser
 - Show a summary of results in the terminal (passed/failed/timeout counts)
+
+### Run options (one-liners)
+
+- Default (opens report on Desktop):
+```bash
+curl -fsSL https://raw.githubusercontent.com/philipnickel/pythonsupport-scripts/main/MacOS/Components/Diagnostics/generate_report.sh | bash
+```
+
+- Save to a specific path and avoid opening a browser (use non-HTML extension):
+```bash
+curl -fsSL https://raw.githubusercontent.com/philipnickel/pythonsupport-scripts/main/MacOS/Components/Diagnostics/generate_report.sh | bash -s -- "/tmp/DTU_Diagnostics_$(date +%s).txt"
+```
+
+- Override repository coordinates at runtime (e.g., test another branch):
+```bash
+curl -fsSL https://raw.githubusercontent.com/philipnickel/pythonsupport-scripts/main/MacOS/Components/Diagnostics/generate_report.sh | REPO_BRANCH=macos-components bash
+```
+
+Notes:
+- By default, the script fetches components from the `main` branch. If a file is missing there, it automatically falls back to `macos-components`.
+- You can override `REPO_OWNER`, `REPO_NAME`, and `REPO_BRANCH` via environment variables as shown above.
 
 ## What it checks
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -35,7 +35,7 @@ Windows support is coming soon. Check back for updates.
 All script documentation is automatically generated from the source code to ensure it stays current.
 
 **MacOS Components:**
-- **[Diagnostics →](generated/diagnostics.md)** - System compatibility checks
+- **[Diagnostics →](macos/components/diagnostics.md)** - System compatibility checks and HTML report
 - **[Homebrew →](generated/homebrew.md)** - Package manager installation
 - **[Python →](generated/python.md)** - Python environment setup  
 - **[VSCode →](generated/vsc.md)** - Code editor and extensions

--- a/docs/content/macos/components/diagnostics.md
+++ b/docs/content/macos/components/diagnostics.md
@@ -1,46 +1,47 @@
 # Diagnostics Component
 
-📖 **This content has been moved to auto-generated documentation: [System Diagnostics](../../generated/components.md#system-diagnostics)**
+Modern diagnostic system for macOS that collects environment data and produces an interactive HTML report.
 
-The auto-generated docs include:
-- Comprehensive system analysis and compatibility checks
-- macOS version, architecture, and environment verification  
-- Usage examples and requirements extracted directly from scripts
+## Quick Start
 
----
-
-## Scripts
-
-### `run.sh`
-
-Main diagnostics script that performs all system checks.
-
-**Checks Performed:**
-
-- macOS version compatibility
-- Available disk space
-- Existing Python installations (ordinary python, miniconda, conda etc.)
-- Homebrew installation status
-
-**Output:**
-
-- Detailed system report
-- Compatibility warnings
-- Outputs to a temporary file in home directory
-
----
-
-## Usage
-
-Run before any installation to identify potential issues:
+Run the diagnostics with a single command:
 
 ```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/dtudk/pythonsupport-scripts/main/MacOS/Components/Diagnostics/run.sh)"
+curl -fsSL https://raw.githubusercontent.com/philipnickel/pythonsupport-scripts/main/MacOS/Components/Diagnostics/generate_report.sh | bash
 ```
 
----
+This downloads all diagnostic components, runs checks in parallel, generates a styled HTML report, opens it in your browser, and prints a summary.
 
-## Integration
+## What it checks
 
-- Used within the GUI to check system compatibility before installation and to check if the installation was successful.
-- Output file integrated into GUI mail-to functionality 
+- Python: installation, configuration, and required packages
+- Conda: installation and environments
+- Development tools: Homebrew and LaTeX
+- VS Code: installation and Python extensions
+- System: hardware/software info and Python development compatibility
+
+## Run options
+
+- Save output without opening a browser (use non-HTML extension):
+```bash
+curl -fsSL https://raw.githubusercontent.com/philipnickel/pythonsupport-scripts/main/MacOS/Components/Diagnostics/generate_report.sh | bash -s -- "/tmp/DTU_Diagnostics_$(date +%s).txt"
+```
+
+- Override repository coordinates at runtime (for testing branches):
+```bash
+curl -fsSL https://raw.githubusercontent.com/philipnickel/pythonsupport-scripts/main/MacOS/Components/Diagnostics/generate_report.sh | REPO_BRANCH=macos-components bash
+```
+
+Notes:
+- By default, components are fetched from the `main` branch and automatically fall back to `macos-components` if needed.
+- You can override `REPO_OWNER`, `REPO_NAME`, and `REPO_BRANCH` as environment variables.
+
+## Output
+
+- HTML report with expandable logs, summary counters, and a “Download Report” button
+- Terminal summary with pass/fail/timeout counts
+- Email template generator for support
+
+## Auto-generated docs
+
+Technical details are included in the auto-generated docs: [Diagnostics (generated)](../../generated/diagnostics.md)

--- a/docs/content/macos/components/index.md
+++ b/docs/content/macos/components/index.md
@@ -8,7 +8,7 @@ Each component is run by 'curling' the bash script from the github repo and then
 
 | Component | Auto-Generated Docs | Manual Docs | Purpose | Dependencies |
 |-----------|--------------------|--------------|---------|--------------| 
-| **Diagnostics** | [Script Details](../../generated/components.md#diagnostics) | [Overview](diagnostics.md) | System compatibility checks | None |
+| **Diagnostics** | [Script Details](../../generated/diagnostics.md) | [Overview](diagnostics.md) | System compatibility checks | None |
 | **Homebrew** | [Script Details](../../generated/components.md#package-manager) | [Overview](homebrew.md) | Package manager installation | None |
 | **Python** | [Script Details](../../generated/components.md#python) | [Overview](python.md) | Miniconda installation and setup | Homebrew |
 | **VSCode** | [Script Details](../../generated/components.md#ide) | [Overview](vscode.md) | Visual Studio Code and extensions | Homebrew |


### PR DESCRIPTION
## Summary
- Default diagnostics remote execution to `main`; add branch fallback (`REPO_BRANCH` → `main` → `macos-components`).
- Centralize raw GitHub fetching into a helper; fix timeout metadata fallback.
- Update Diagnostics README and docs with correct one-liners and usage options.

## Test plan
- Run from any directory:
  ```bash
  curl -fsSL https://raw.githubusercontent.com/philipnickel/pythonsupport-scripts/fix/diagnostics-curl-defaults/MacOS/Components/Diagnostics/generate_report.sh | bash
  ```
- Verify HTML report opens and components download from `main` by default.
- Override branch to `macos-components`:
  ```bash
  REPO_BRANCH=macos-components curl -fsSL https://raw.githubusercontent.com/philipnickel/pythonsupport-scripts/fix/diagnostics-curl-defaults/MacOS/Components/Diagnostics/generate_report.sh | bash
  ```
- Confirm README and docs reflect updated commands and behavior.