### PR TITLE
Orchestrator: run diagnostics HTML report as final step

### DIFF
--- a/MacOS/Components/orchestrators/first_year_students.sh
+++ b/MacOS/Components/orchestrators/first_year_students.sh
@@ -66,3 +66,7 @@ else
 fi
 
 log_info "Script has finished. You may now close the terminal..."
+
+# Final step: run diagnostics report to validate installation and capture environment details
+log_info "Launching final diagnostics report (an HTML report will open)..."
+piwik_log 'diagnostics_final_report' /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/${DIAG_REMOTE_PS:-philipnickel/pythonsupport-scripts}/${DIAG_BRANCH_PS:-main}/MacOS/Components/Diagnostics/generate_report.sh)"


### PR DESCRIPTION
## Summary
Run the new Diagnostics HTML report generator at the end of the first_year_students orchestrator to validate the installation and produce a sharable report.

- Uses `generate_report.sh` which defaults to `main` and supports branch fallback
- Logs analytics event `diagnostics_final_report`
- Supports overrides via `DIAG_REMOTE_PS` and `DIAG_BRANCH_PS`

## Test plan
1. Execute orchestrator from a macOS machine:
```bash
/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/philipnickel/pythonsupport-scripts/feature-diagnostics-last-step/MacOS/Components/orchestrators/first_year_students.sh)"
```
2. After installs, verify that an HTML Diagnostics report opens and a summary is printed to the terminal.
3. Optionally override diagnostics branch:
```bash
DIAG_BRANCH_PS=macos-components /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/philipnickel/pythonsupport-scripts/feature-diagnostics-last-step/MacOS/Components/orchestrators/first_year_students.sh)"
```