### PR TITLE
Fix macOS uninstall functionality - Phase 1

### DIFF
--- a/MacOS/Components/Core/pre_install.sh
+++ b/MacOS/Components/Core/pre_install.sh
@@ -26,29 +26,36 @@ export SKIP_VSCODE_INSTALL=false
 if [ -d "$MINIFORGE_PATH" ] && [ -x "$MINIFORGE_PATH/bin/conda" ]; then
     echo "• Miniforge found"
     echo "Everything appears to be already installed!"
-    echo "Cancel installation? (y/n)"
-    read -r response
-    if [[ "$response" =~ ^[Yy]([Ee][Ss])?$ ]]; then
-        echo "Installation cancelled - Miniforge already present"
-        exit 0
+    if [[ "${NONINTERACTIVE:-}" == "true" ]]; then
+        echo "• Running in non-interactive mode - continuing with installation..."
+    else
+        echo "Cancel installation? (y/n)"
+        read -r response
+        if [[ "$response" =~ ^[Yy]([Ee][Ss])?$ ]]; then
+            echo "Installation cancelled - Miniforge already present"
+            exit 0
+        fi
+        echo "• Continuing with installation anyway..."
     fi
-    echo "• Continuing with installation anyway..."
 
 # Check for other conda installations  
 elif [ -d "$HOME/anaconda3" ] || [ -d "$HOME/miniconda3" ] || [ -d "/opt/anaconda3" ] || [ -d "/opt/miniconda3" ] || command -v conda >/dev/null 2>&1; then
     echo "• Other conda installation detected"
     echo "DTU Python Support only works with Miniforge."
-    echo "Uninstall existing conda and continue? (y/n)"
-    read -r response
-    
-    if [[ "$response" =~ ^[Yy]([Ee][Ss])?$ ]]; then
-        echo "• Uninstalling existing conda..."
-        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/${REMOTE_PS}/${BRANCH_PS}/MacOS/Components/Core/uninstall_conda.sh)"
-        echo "• Continuing with Miniforge installation..."
+    if [[ "${NONINTERACTIVE:-}" == "true" ]]; then
+        echo "• Running in non-interactive mode - automatically uninstalling existing conda..."
     else
-        echo "Installation aborted."
-        exit 1
+        echo "Uninstall existing conda and continue? (y/n)"
+        read -r response
+        if [[ ! "$response" =~ ^[Yy]([Ee][Ss])?$ ]]; then
+            echo "Installation aborted."
+            exit 1
+        fi
+        echo "• Uninstalling existing conda..."
     fi
+    
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/${REMOTE_PS}/${BRANCH_PS}/MacOS/Components/Core/uninstall_conda.sh)"
+    echo "• Continuing with Miniforge installation..."
 fi
 
 # Check for VS Code

--- a/MacOS/Components/Core/uninstall_conda.sh
+++ b/MacOS/Components/Core/uninstall_conda.sh
@@ -1,148 +1,16 @@
 #!/bin/bash
-# @doc
-# @name: Conda Uninstall Script
-# @description: Completely removes conda/miniconda/miniforge installations
-# @category: Core
-# @usage: ./uninstall_conda.sh
-# @requirements: macOS system
-# @notes: Removes conda installations and cleans up shell configurations
-# @/doc
+# Simple conda uninstaller for DTU Python Support
 
-# Load configuration
-source <(curl -fsSL "https://raw.githubusercontent.com/${REMOTE_PS}/${BRANCH_PS}/MacOS/config.sh")
+echo "Removing conda installations..."
 
-echo "DTU Conda Uninstall Script"
-echo "=========================="
-echo ""
+# Remove conda directories
+rm -rf "$HOME/miniforge3" "$HOME/miniconda3" "$HOME/anaconda3" "$HOME/.conda" 2>/dev/null
 
-# Find conda installations
-CONDA_PATHS=()
-CONDA_TYPES=()
-
-# Check common installation locations
-if [ -d "$HOME/miniforge3" ]; then
-    CONDA_PATHS+=("$HOME/miniforge3")
-    CONDA_TYPES+=("Miniforge")
-fi
-
-if [ -d "$HOME/miniconda3" ]; then
-    CONDA_PATHS+=("$HOME/miniconda3")
-    CONDA_TYPES+=("Miniconda")
-fi
-
-if [ -d "$HOME/anaconda3" ]; then
-    CONDA_PATHS+=("$HOME/anaconda3")
-    CONDA_TYPES+=("Anaconda")
-fi
-
-if [ -d "/opt/miniconda3" ]; then
-    CONDA_PATHS+=("/opt/miniconda3")
-    CONDA_TYPES+=("Miniconda (system)")
-fi
-
-if [ -d "/opt/anaconda3" ]; then
-    CONDA_PATHS+=("/opt/anaconda3")
-    CONDA_TYPES+=("Anaconda (system)")
-fi
-
-# Show what was found
-if [ ${#CONDA_PATHS[@]} -eq 0 ]; then
-    echo "No conda installations found to uninstall."
-    exit 0
-fi
-
-echo "Found conda installations:"
-for i in "${!CONDA_PATHS[@]}"; do
-    echo "• ${CONDA_TYPES[$i]}: ${CONDA_PATHS[$i]}"
-done
-echo ""
-
-# Confirm uninstall (skip prompt in non-interactive mode or CI)
-echo "This will completely remove all conda installations and clean up your shell configuration."
-echo "WARNING: This action cannot be undone!"
-
-# Always proceed with uninstall - no prompting
-echo "Running in non-interactive mode - proceeding with uninstall..."
-
-# 2. Remove installation directories
-for i in "${!CONDA_PATHS[@]}"; do
-    path="${CONDA_PATHS[$i]}"
-    type="${CONDA_TYPES[$i]}"
-    
-    if [ -d "$path" ]; then
-        echo "• Removing $type installation: $path"
-        
-        # Remove installation directory (skip system installations that require sudo)
-        if [[ "$path" == /opt/* ]]; then
-            echo "  ⚠  Skipping system installation $path (requires administrator privileges)"
-            echo "  ⚠  Please remove manually if needed: sudo rm -rf '$path'"
-        else
-            rm -rf "$path"
-        fi
-        
-        if [ $? -eq 0 ]; then
-            echo "  ✓ Successfully removed $path"
-        else
-            echo "  ✗ Failed to remove $path"
-        fi
-    fi
-done
-
-# 3. Clean up shell configuration files
-echo "• Cleaning up shell configuration files..."
-SHELL_FILES=(
-    "$HOME/.bashrc"
-    "$HOME/.bash_profile" 
-    "$HOME/.zshrc"
-    "$HOME/.profile"
-)
-
-for file in "${SHELL_FILES[@]}"; do
+# Clean shell configs - only remove conda initialization blocks
+for file in ~/.bashrc ~/.zshrc ~/.bash_profile; do
     if [ -f "$file" ]; then
-        echo "  Cleaning $file"
-        
-        # Create backup
-        cp "$file" "${file}.backup-$(date +%Y%m%d_%H%M%S)"
-        
-        # Remove conda-related lines
-        sed -i '' '/# >>> conda initialize >>>/,/# <<< conda initialize <<</d' "$file" 2>/dev/null || true
-        sed -i '' '/miniforge3/d' "$file" 2>/dev/null || true
-        sed -i '' '/miniconda3/d' "$file" 2>/dev/null || true
-        sed -i '' '/anaconda3/d' "$file" 2>/dev/null || true
-        sed -i '' '/conda/d' "$file" 2>/dev/null || true
+        sed -i.bak '/# >>> conda initialize >>>/,/# <<< conda initialize <<</d' "$file" 2>/dev/null
     fi
 done
 
-# 4. Remove conda-related environment variables and aliases
-echo "• Cleaning up environment variables..."
-
-# Remove from current session
-unset CONDA_DEFAULT_ENV CONDA_EXE CONDA_PREFIX CONDA_PROMPT_MODIFIER CONDA_PYTHON_EXE CONDA_SHLVL
-unset _CE_CONDA _CE_M
-
-# 5. Clean up PATH
-echo "• Cleaning up PATH..."
-export PATH=$(echo "$PATH" | sed -e 's/:*[^:]*conda[^:]*:*/:/g' -e 's/^://' -e 's/:$//')
-
-# 6. Remove conda configuration directory
-if [ -d "$HOME/.conda" ]; then
-    echo "• Removing conda configuration directory: $HOME/.conda"
-    rm -rf "$HOME/.conda"
-fi
-
-# 7. Remove conda environments directory (if separate)
-if [ -d "$HOME/.conda-env" ]; then
-    echo "• Removing conda environments directory: $HOME/.conda-env"
-    rm -rf "$HOME/.conda-env"
-fi
-
-echo ""
 echo "✓ Conda uninstall completed!"
-echo ""
-echo "Important notes:"
-echo "• Shell configuration files have been cleaned up"  
-echo "• Backups of shell files were created with .backup-* suffix"
-echo "• You may need to restart your terminal or run 'source ~/.bashrc' (or ~/.zshrc)"
-echo "• The PATH has been cleaned up for this session"
-echo ""
-echo "You can now run the DTU installer to install Miniforge."# Updated Mon Aug 25 18:45:25 CEST 2025

--- a/MacOS/uninstall.sh
+++ b/MacOS/uninstall.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# DTU Python Support - Complete Uninstaller
+# Usage: /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/dtudk/pythonsupport-scripts/main/MacOS/uninstall.sh)"
+
+echo "DTU Python Support - Complete Uninstaller"
+echo "=========================================="
+echo ""
+
+echo "This will remove:"
+echo "• All conda/Python installations (miniforge, miniconda, anaconda)"
+echo "• Python packages and environments"
+echo "• Shell configuration changes"
+echo "• VS Code and extensions (optional)"
+echo ""
+
+# Ask about VS Code
+read -p "Also remove VS Code and extensions? (y/n): " -r vscode_response
+
+echo ""
+echo "Starting uninstall process..."
+echo ""
+
+# Remove conda installations
+echo "🐍 Removing Python/conda installations..."
+rm -rf "$HOME/miniforge3" "$HOME/miniconda3" "$HOME/anaconda3" "$HOME/.conda" 2>/dev/null
+
+# Clean shell configs - only remove conda initialization blocks
+echo "🧹 Cleaning shell configurations..."
+for file in ~/.bashrc ~/.zshrc ~/.bash_profile; do
+    if [ -f "$file" ]; then
+        sed -i.bak '/# >>> conda initialize >>>/,/# <<< conda initialize <<</d' "$file" 2>/dev/null
+    fi
+done
+
+# Remove VS Code if requested
+if [[ "$vscode_response" =~ ^[Yy]([Ee][Ss])?$ ]]; then
+    echo "💻 Removing VS Code..."
+    rm -rf "/Applications/Visual Studio Code.app" 2>/dev/null
+    sudo rm -f /usr/local/bin/code 2>/dev/null
+    rm -rf "$HOME/.vscode" 2>/dev/null
+fi
+
+echo ""
+echo "✅ Uninstall completed!"
+echo ""
+echo "Notes:"
+echo "• Restart your terminal to see changes"
+echo "• Shell config backups were created with .bak extension"
+echo ""


### PR DESCRIPTION
## Summary
- Fixed hanging issue in main installer when uninstalling existing conda installations
- Simplified uninstall process to be more reliable and user-friendly
- Added standalone uninstall script for complete system cleanup

## Changes Made
- **Fixed hanging uninstall**: Simplified `uninstall_conda.sh` to remove config dependency that was causing hangs
- **Added NONINTERACTIVE mode**: Pre-install script now properly handles non-interactive mode for automated installations
- **Improved shell cleanup**: Fixed sed command to only remove conda initialization blocks, preventing syntax errors
- **Standalone uninstaller**: Created `MacOS/uninstall.sh` for complete removal including optional VS Code cleanup

## Test plan
- [x] Test uninstall script runs without hanging
- [x] Test shell configuration cleanup doesn't break syntax
- [x] Test NONINTERACTIVE mode works properly
- [ ] CI tests pass
- [ ] Manual testing on clean macOS system

🤖 Generated with [Claude Code](https://claude.ai/code)