### PR TITLE
CI bootstrap: run InstallerV2 tests on PRs

### DIFF
--- a/.github/workflows/installerv2-ci.yml
+++ b/.github/workflows/installerv2-ci.yml
@@ -1,0 +1,63 @@
+name: InstallerV2 CI
+
+on:
+  pull_request_target:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build-and-smoke:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout base (for context)
+        uses: actions/checkout@v4
+
+      - name: Checkout PR head
+        if: github.event_name == 'pull_request_target'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: pr_head
+
+      - name: Show workspace files (debug)
+        run: |
+          echo "pwd=$(pwd)"
+          ls -la
+          echo "PR head tree:" && ls -la pr_head || true
+
+      - name: Build universal installer
+        shell: bash
+        run: |
+          cd pr_head || true
+          if [[ -d pr_head ]]; then cd pr_head; fi
+          if [[ -f InstallerV2/build/create-universal-installer.sh ]]; then
+            bash InstallerV2/build/create-universal-installer.sh
+            ls -la dist
+          else
+            echo "InstallerV2 not found in PR head; skipping build" && exit 1
+          fi
+
+      - name: Smoke test (CLI, dry-run)
+        shell: bash
+        env:
+          CI: true
+        run: |
+          cd pr_head
+          ./dist/dtu-installer.sh --cli --dry-run
+
+      - name: Smoke test (GUI, dry-run)
+        shell: bash
+        env:
+          CI: true
+        run: |
+          cd pr_head
+          ./dist/dtu-installer.sh --gui --dry-run
+
+      - name: Direct run via repo entry (CLI, dry-run)
+        shell: bash
+        env:
+          CI: true
+        run: |
+          cd pr_head
+          ./InstallerV2/bin/install.sh --cli --dry-run
+


### PR DESCRIPTION
Bootstrap workflow that runs InstallerV2 build + smoke tests on pull_request_target by explicitly checking out the PR head SHA.

- Uses pull_request_target to ensure the base workflow runs.
- Checks out PR head into pr_head/ and builds from there.
- Runs CLI and GUI dry-run smoke tests.

Merge this first; then the existing InstallerV2 PR will pass CI.